### PR TITLE
Fixed missing dependency + updated dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
-version = "1.1-SNAPSHOT"
+version = "1.1"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
-version = "1.1"
+version = "1.1.1"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,8 +37,9 @@ repositories {
 dependencies {
     tCompileOnly("io.papermc.paper:paper-api:1.20-R0.1-SNAPSHOT")
     tCompileOnly("me.clip:placeholderapi:2.11.5")
-    tImplementation("net.kyori:adventure-api:4.15.0")
-    tImplementation("net.kyori:adventure-text-minimessage:4.15.0")
+    tImplementation("net.kyori:adventure-api:4.20.0")
+    tImplementation("net.kyori:adventure-text-serializer-legacy:4.20.0")
+    tImplementation("net.kyori:adventure-text-minimessage:4.20.0")
 
     testImplementation("org.mockito:mockito-core:3.12.4")
     testImplementation("org.mockito:mockito-inline:3.12.4")


### PR DESCRIPTION
Without this fix, an exception will be thrown.

```
[17:03:04] [Server thread/ERROR]: Command exception: /papi parse me %minim_section_player_displayname%
org.bukkit.command.CommandException: Unhandled exception executing command 'papi' in plugin PlaceholderAPI v2.11.6
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.command.brigadier.bukkit.BukkitCommandNode$BukkitBrigCommand.run(BukkitCommandNode.java:82) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at com.mojang.brigadier.context.ContextChain.runExecutable(ContextChain.java:73) ~[brigadier-1.3.10.jar:?]
	at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:30) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:13) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.commands.execution.UnboundEntryAction.lambda$bind$0(UnboundEntryAction.java:8) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.commands.execution.CommandQueueEntry.execute(CommandQueueEntry.java:5) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.commands.execution.ExecutionContext.runCommandQueue(ExecutionContext.java:105) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.commands.Commands.executeCommandInContext(Commands.java:450) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.commands.Commands.performCommand(Commands.java:357) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.commands.Commands.performCommand(Commands.java:347) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.commands.Commands.performCommand(Commands.java:341) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.performUnsignedChatCommand(ServerGamePacketListenerImpl.java:2214) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$11(ServerGamePacketListenerImpl.java:2187) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:155) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1448) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:176) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:129) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1428) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1422) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:139) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:1379) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1387) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1264) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310) ~[paper-1.21.4.jar:1.21.4-224-0cf7315]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.lang.NoClassDefFoundError: dev/bluetree242/minim/dependencies/adventure/text/serializer/legacy/LegacyComponentSerializer
	at dev.bluetree242.minim.MiniMExpansion.convert(MiniMExpansion.java:48) ~[?:?]
	at dev.bluetree242.minim.MiniMExpansion.onRequest(MiniMExpansion.java:38) ~[?:?]
	at PlaceholderAPI-2.11.6(1).jar/me.clip.placeholderapi.replacer.CharsReplacer.apply(CharsReplacer.java:119) ~[PlaceholderAPI-2.11.6(1).jar:?]
	at PlaceholderAPI-2.11.6(1).jar/me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(PlaceholderAPI.java:71) ~[PlaceholderAPI-2.11.6(1).jar:?]
	at PlaceholderAPI-2.11.6(1).jar/me.clip.placeholderapi.commands.impl.local.CommandParse.evaluateParseSingular(CommandParse.java:118) ~[PlaceholderAPI-2.11.6(1).jar:?]
	at PlaceholderAPI-2.11.6(1).jar/me.clip.placeholderapi.commands.impl.local.CommandParse.evaluate(CommandParse.java:57) ~[PlaceholderAPI-2.11.6(1).jar:?]
	at PlaceholderAPI-2.11.6(1).jar/me.clip.placeholderapi.commands.PlaceholderCommandRouter.onCommand(PlaceholderCommandRouter.java:114) ~[PlaceholderAPI-2.11.6(1).jar:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
	... 27 more
Caused by: java.lang.ClassNotFoundException: dev.bluetree242.minim.dependencies.adventure.text.serializer.legacy.LegacyComponentSerializer
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445) ~[?:?]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:593) ~[?:?]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?]
	at dev.bluetree242.minim.MiniMExpansion.convert(MiniMExpansion.java:48) ~[?:?]
	at dev.bluetree242.minim.MiniMExpansion.onRequest(MiniMExpansion.java:38) ~[?:?]
	at PlaceholderAPI-2.11.6(1).jar/me.clip.placeholderapi.replacer.CharsReplacer.apply(CharsReplacer.java:119) ~[PlaceholderAPI-2.11.6(1).jar:?]
	at PlaceholderAPI-2.11.6(1).jar/me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(PlaceholderAPI.java:71) ~[PlaceholderAPI-2.11.6(1).jar:?]
	at PlaceholderAPI-2.11.6(1).jar/me.clip.placeholderapi.commands.impl.local.CommandParse.evaluateParseSingular(CommandParse.java:118) ~[PlaceholderAPI-2.11.6(1).jar:?]
	at PlaceholderAPI-2.11.6(1).jar/me.clip.placeholderapi.commands.impl.local.CommandParse.evaluate(CommandParse.java:57) ~[PlaceholderAPI-2.11.6(1).jar:?]
	at PlaceholderAPI-2.11.6(1).jar/me.clip.placeholderapi.commands.PlaceholderCommandRouter.onCommand(PlaceholderCommandRouter.java:114) ~[PlaceholderAPI-2.11.6(1).jar:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
	... 27 more
```